### PR TITLE
Allow the dockerfile to be specified in action inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
     description: Fly app name
   image:
     description: Optional pre-existing Docker image to use
+  dockerfile:
+    description: Optional path to a Dockerfile use for building the image
   region:
     description: Region to launch the app in (alternatively, set the env FLY_REGION)
   org:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,7 @@ postgres_app="${INPUT_POSTGRES:-$REPO_NAME-pr-$PR_NUMBER-postgres}"
 region="${INPUT_REGION:-${FLY_REGION:-ord}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"
+dockerfile="$INPUT_DOCKERFILE"
 memory="$INPUT_MEMORY"
 
 if ! echo "$app" | grep "$PR_NUMBER"; then
@@ -51,7 +52,7 @@ fi
 
 # Deploy the Fly app, creating it first if needed.
 if ! flyctl status --app "$app"; then
-  flyctl launch --no-deploy --copy-config --name "$app" --image "$image" --region "$region" --org "$org"
+  flyctl launch --no-deploy --copy-config --name "$app" --image "$image" --dockerfile "$dockerfile" --region "$region" --org "$org"
   if [ -n "$INPUT_SECRETS" ]; then
     echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
   fi


### PR DESCRIPTION
https://community.fly.io/t/detected-a-phoenix-app-with-dockerfile-specified-in-fly-toml/5804

Flyctl is no longer auto-detecting that our app has a Dockerfile b/c the precedence has been changed and now it wants to generate a new dockerfile with `mix release` :(