### PR TITLE
fix: hard-code the flyctl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 RUN apk add --no-cache curl jq
 
-RUN curl -L https://fly.io/install.sh && FLYCTL_INSTALL=/usr/local install.sh v0.0.521
+RUN curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/usr/local sh v0.0.521
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine
 
 RUN apk add --no-cache curl jq
 
-RUN curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/usr/local sh
+RUN curl -L https://fly.io/install.sh > install.sh
+RUN FLYCTL_INSTALL=/usr/local install.sh v0.0.521
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM alpine
 
 RUN apk add --no-cache curl jq
 
-RUN curl -L https://fly.io/install.sh > install.sh
-RUN FLYCTL_INSTALL=/usr/local install.sh v0.0.521
+RUN curl -L https://fly.io/install.sh && FLYCTL_INSTALL=/usr/local install.sh v0.0.521
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 RUN apk add --no-cache curl jq
 
-RUN curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/usr/local sh v0.0.521
+RUN curl -LJO https://fly.io/install.sh && chmod +x install.sh && FLYCTL_INSTALL=/usr/local ./install.sh v0.0.521
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Working around the change that caused the fly CLI to try to use phoenix defaults instead of our Dockerfile

https://community.fly.io/t/flyctl-trying-to-auto-detect-phoenix-even-though-i-specified-a-dockerfile/12394