### PR TITLE
fix: add wait time

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,7 @@ if ! flyctl status --app "$app"; then
     echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
   fi
   flyctl postgres attach "$postgres_app" --app "$app"
-  flyctl deploy $detach --app "$app" --region "$region" --image "$image" --strategy immediate
+  flyctl deploy $detach --app "$app" --region "$region" --image "$image" --strategy immediate --wait-timeout 240
   sleep 10
   flyctl scale vm shared-cpu-2x --app "$app" --group app
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,7 +78,7 @@ if ! flyctl status --app "$app"; then
 
   statusmessage="Review app created. It may take a few minutes for the app to deploy."
 elif [ "$EVENT_TYPE" = "synchronize" ]; then
-  flyctl deploy $detach --app "$app" --region "$region" --image "$image" --strategy immediate
+  flyctl deploy $detach --app "$app" --region "$region" --image "$image" --strategy immediate --wait-timeout 240
   statusmessage="Review app updated. It may take a few minutes for your changes to be deployed."
 fi
 


### PR DESCRIPTION
addressed this error
```
2023-06-26T21:30:32.8023526Z Error: release command failed - aborting deployment. error waiting for release_command machine 0e2865d3dc0867 to start: timeout reached waiting for machine to started failed to wait for VM 0e2865d3dc0867 in started state: Get "https://api.machines.dev/v1/apps/platform-pr-4365/machines/0e2865d3dc0867/wait?
instance_id=01H3WSQE8Q0R6CR8AAKJT6HBGX&state=started&timeout=60": net/http: request canceled
2023-06-26T21:30:32.8026910Z note: you can change this timeout with the --wait-timeout flag
```