### PR TITLE
add oban build time secrets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: Optionally create a new Postgres cluster for the app
     required: false
   secrets:
-    description: Secrets to be set on the app. Values are read as `name=value`
+    description: Secrets to be set on the app. Values are read as `name=value`. Multiple values should be delineated by spaces or on separate lines.
     required: false
   memory:
     description: Optionally allows users to scale the memory for their app.
@@ -42,5 +42,5 @@ inputs:
     description: Specify the version of the flyctl command-line tool to use
     required: false
   build_secrets:
-    description: Secrets to be set at build time. Values are read as `name=value`
+    description: Secrets to be set at build time. Values are read as `name=value`. Multiple values should be delineated by spaces or on separate lines.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -41,3 +41,9 @@ inputs:
   flyctl_version:
     description: Specify the version of the flyctl command-line tool to use
     required: false
+  oban_key_fingerprint:
+    description: The fingerprint of the Oban key to use for the app (required at build time)
+    required: false
+  oban_license_key:
+    description: The Oban license key to use for the app (required at build time)
+    required: false

--- a/action.yml
+++ b/action.yml
@@ -41,9 +41,6 @@ inputs:
   flyctl_version:
     description: Specify the version of the flyctl command-line tool to use
     required: false
-  oban_key_fingerprint:
-    description: The fingerprint of the Oban key to use for the app (required at build time)
-    required: false
-  oban_license_key:
-    description: The Oban license key to use for the app (required at build time)
+  build_secrets:
+    description: Secrets to be set at build time. Values are read as `name=value`
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,10 +65,14 @@ if [ -n "$INPUT_POSTGRES" ]; then
   fi
 fi
 
-if [ -n "$INPUT_OBAN_KEY_FINGERPRINT" && -n "$INPUT_OBAN_LICENSE_KEY" ]; then
-  $build_secrets = "--build-secret OBAN_KEY_FINGERPRINT=$INPUT_OBAN_KEY_FINGERPRINT --build-secret OBAN_LICENSE_KEY=$INPUT_OBAN_LICENSE_KEY"
-else
-  $build_secrets = ""
+# Build secrets
+$build_secrets = ""
+if [ -n "$INPUT_BUILD_SECRETS" ]; then
+  $build_secrets=""
+  $secrets_list=($INPUT_BUILD_SECRETS)
+  for secret in ${secrets_list[@]}; do
+    $build_secrets+="--build-secret $secret "
+  done
 fi
 
 # Deploy the Fly app, creating it first if needed.


### PR DESCRIPTION
In order to add oban web, the secrets need to be available at build time.